### PR TITLE
[PR] 카프카 클러스터에 메시지 발행시, 비동기 콜백을 활용한 성능 개선

### DIFF
--- a/sns-feed-service/application/api/command-server/src/main/kotlin/com/hyoseok/service/post/PostCreateService.kt
+++ b/sns-feed-service/application/api/command-server/src/main/kotlin/com/hyoseok/service/post/PostCreateService.kt
@@ -20,6 +20,7 @@ import com.hyoseok.service.dto.PostCreateResultDto
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.sql.Timestamp
@@ -35,6 +36,8 @@ class PostCreateService(
     private val memberReadRepository: MemberReadRepository,
     private val kafkaProducer: KafkaProducer,
 ) {
+
+    private val logger = KotlinLogging.logger {}
 
     fun execute(dto: PostCreateDto): PostCreateResultDto {
         val post: Post = dto.toEntity()
@@ -121,7 +124,7 @@ class PostCreateService(
         )
 
     private suspend fun sendFeedToFollower(postId: Long, createdAt: LocalDateTime, followerId: Long) {
-        kafkaProducer.send(
+        kafkaProducer.sendAsync(
             event = FollowerSendEventDto(postId = postId, createdAt = createdAt, followerId = followerId),
             topic = KafkaTopics.SNS_FEED,
         )

--- a/sns-feed-service/infrastructure/kafka/src/main/kotlin/com/hyoseok/publisher/KafkaProducer.kt
+++ b/sns-feed-service/infrastructure/kafka/src/main/kotlin/com/hyoseok/publisher/KafkaProducer.kt
@@ -29,6 +29,14 @@ class KafkaProducer(
         }
     }
 
+    fun <T : Any> sendAsync(event: T, topic: String) {
+        execute {
+            kafkaTemplate
+                .send(topic, jacksonObjectMapper.writeValueAsString(event))
+                .addCallback(KafkaProducerCallback())
+        }
+    }
+
     private fun execute(func: () -> Unit) {
         try {
             func()

--- a/sns-feed-service/infrastructure/kafka/src/main/kotlin/com/hyoseok/publisher/KafkaProducerCallback.kt
+++ b/sns-feed-service/infrastructure/kafka/src/main/kotlin/com/hyoseok/publisher/KafkaProducerCallback.kt
@@ -1,0 +1,22 @@
+package com.hyoseok.publisher
+
+import mu.KotlinLogging
+import org.springframework.kafka.support.SendResult
+import org.springframework.util.concurrent.ListenableFutureCallback
+
+class KafkaProducerCallback : ListenableFutureCallback<SendResult<String, String>> {
+
+    private val logger = KotlinLogging.logger {}
+
+    override fun onSuccess(result: SendResult<String, String>?) {
+        if (result == null) {
+            return logger.error { "SendResult is NULL" }
+        }
+
+        logger.info { "partition: ${result.recordMetadata.partition()}, offset: ${result.recordMetadata.offset()}" }
+    }
+
+    override fun onFailure(ex: Throwable) {
+        logger.error { ex.localizedMessage }
+    }
+}


### PR DESCRIPTION
### [ 이슈 ]

- #84

### [ 내용 ]

- `KafkaProducerCallback` 클래스 구현
- `비동기` 로직 구현

### [ 결과 ]

- `10,000` 개 메시지를 발행하는데,  `17분` 에서 `2 ~ 3초` 이내로 개선 했음.