### PR TITLE
[PR] Wish 전용의 Redis 서버 연결

### DIFF
--- a/sns-feed-service-v2/application/api/src/main/resources/application.yml
+++ b/sns-feed-service-v2/application/api/src/main/resources/application.yml
@@ -3,13 +3,17 @@ server:
   tomcat:
     threads:
       min-spare: 20
-      max: 100
+      max: 150
 
 spring:
   profiles:
     active: develop
 
   post:
+    redis:
+      enable: true
+
+  wish:
     redis:
       enable: true
 

--- a/sns-feed-service-v2/application/query-api/src/main/resources/application.yml
+++ b/sns-feed-service-v2/application/query-api/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
   tomcat:
     threads:
       min-spare: 20
-      max: 100
+      max: 150
 
 spring:
   profiles:
@@ -14,6 +14,10 @@ spring:
       enable: true
 
   feed:
+    redis:
+      enable: true
+
+  wish:
     redis:
       enable: true
 

--- a/sns-feed-service-v2/domain/redis/src/main/kotlin/com/hyoseok/config/WishRedisConfig.kt
+++ b/sns-feed-service-v2/domain/redis/src/main/kotlin/com/hyoseok/config/WishRedisConfig.kt
@@ -10,7 +10,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Primary
 import org.springframework.data.redis.connection.RedisClusterConfiguration
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration
@@ -20,42 +19,41 @@ import java.time.Duration
 
 @Configuration
 @EnableCaching(proxyTargetClass = true)
-@ConditionalOnProperty(prefix = "spring.post.redis", name = ["enable"], havingValue = "true")
-class PostRedisConfig(
-    @Value("\${spring.post.redis.mode}")
+@ConditionalOnProperty(prefix = "spring.wish.redis", name = ["enable"], havingValue = "true")
+class WishRedisConfig(
+    @Value("\${spring.wish.redis.mode}")
     private val mode: RedisMode,
 
-    @Value("\${spring.post.redis.nodes}")
+    @Value("\${spring.wish.redis.nodes}")
     private val nodes: List<String>,
 
-    @Value("\${spring.post.redis.lettuce.pool.max-active}")
+    @Value("\${spring.wish.redis.lettuce.pool.max-active}")
     private val maxActive: Int,
 
-    @Value("\${spring.post.redis.lettuce.pool.max-idle}")
+    @Value("\${spring.wish.redis.lettuce.pool.max-idle}")
     private val maxIdle: Int,
 
-    @Value("\${spring.post.redis.lettuce.pool.max-idle}")
+    @Value("\${spring.wish.redis.lettuce.pool.max-idle}")
     private val minIdle: Int,
 
-    @Value("\${spring.post.redis.lettuce.pool.max-wait}")
+    @Value("\${spring.wish.redis.lettuce.pool.max-wait}")
     private val maxWait: Long,
 ) {
 
     private val logger = KotlinLogging.logger {}
 
     @Bean
-    @Primary
-    fun postRedisConnectionFactory(): RedisConnectionFactory {
+    fun wishRedisConnectionFactory(): RedisConnectionFactory {
         val lettuceConnectionFactory: LettuceConnectionFactory = when (mode) {
             Standalone -> {
-                logger.info { "post redis standalone mode" }
+                logger.info { "wish redis standalone mode" }
 
                 val (host: String, port: Int) = getHostAndPort()
                 LettuceConnectionFactory(RedisStandaloneConfiguration(host, port), lettucePoolingClientConfiguration())
             }
 
             Cluster -> {
-                logger.info { "post redis cluster mode" }
+                logger.info { "wish redis cluster mode" }
 
                 LettuceConnectionFactory(RedisClusterConfiguration(nodes), lettucePoolingClientConfiguration())
             }
@@ -81,7 +79,7 @@ class PostRedisConfig(
         poolConfig.setMaxWait(Duration.ofMillis(maxWait))
 
         return LettucePoolingClientConfiguration.builder()
-            .clientName("post-redis-client")
+            .clientName("wish-redis-client")
             .readFrom(ReadFrom.REPLICA_PREFERRED)
             .poolConfig(poolConfig)
             .build()

--- a/sns-feed-service-v2/domain/redis/src/main/kotlin/com/hyoseok/config/WishRedisTemplateConfig.kt
+++ b/sns-feed-service-v2/domain/redis/src/main/kotlin/com/hyoseok/config/WishRedisTemplateConfig.kt
@@ -1,0 +1,29 @@
+package com.hyoseok.config
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+@Configuration
+@ConditionalOnProperty(prefix = "spring.wish.redis", name = ["enable"], havingValue = "true")
+class WishRedisTemplateConfig {
+
+    @Bean
+    fun wishRedisTemplate(
+        @Qualifier("wishRedisConnectionFactory")
+        redisConnectionFactory: RedisConnectionFactory,
+    ): RedisTemplate<String, String?> {
+        val stringRedisSerializer = StringRedisSerializer()
+        return RedisTemplate<String, String?>().apply {
+            setConnectionFactory(redisConnectionFactory)
+            keySerializer = stringRedisSerializer
+            valueSerializer = stringRedisSerializer
+            hashKeySerializer = stringRedisSerializer
+            hashValueSerializer = stringRedisSerializer
+        }
+    }
+}

--- a/sns-feed-service-v2/domain/redis/src/main/kotlin/com/hyoseok/wish/repository/WishRedisRepositoryImpl.kt
+++ b/sns-feed-service-v2/domain/redis/src/main/kotlin/com/hyoseok/wish/repository/WishRedisRepositoryImpl.kt
@@ -10,9 +10,9 @@ import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Repository
 
 @Repository
-@ConditionalOnProperty(prefix = "spring.post.redis", name = ["enable"], havingValue = "true")
+@ConditionalOnProperty(prefix = "spring.wish.redis", name = ["enable"], havingValue = "true")
 class WishRedisRepositoryImpl(
-    @Qualifier("postRedisTemplate")
+    @Qualifier("wishRedisTemplate")
     private val redisTemplate: RedisTemplate<String, String?>,
 ) : WishRedisRepository {
 

--- a/sns-feed-service-v2/domain/redis/src/main/kotlin/com/hyoseok/wish/repository/WishRedisTransactionRepositoryImpl.kt
+++ b/sns-feed-service-v2/domain/redis/src/main/kotlin/com/hyoseok/wish/repository/WishRedisTransactionRepositoryImpl.kt
@@ -8,9 +8,9 @@ import org.springframework.stereotype.Repository
 import java.util.concurrent.TimeUnit.SECONDS
 
 @Repository
-@ConditionalOnProperty(prefix = "spring.post.redis", name = ["enable"], havingValue = "true")
+@ConditionalOnProperty(prefix = "spring.wish.redis", name = ["enable"], havingValue = "true")
 class WishRedisTransactionRepositoryImpl(
-    @Qualifier("postRedisTemplate")
+    @Qualifier("wishRedisTemplate")
     private val redisTemplate: RedisTemplate<String, String?>,
     private val wishRedisRepository: WishRedisRepository,
 ) : WishRedisTransactionRepository {

--- a/sns-feed-service-v2/domain/redis/src/main/kotlin/com/hyoseok/wish/service/WishRedisReadService.kt
+++ b/sns-feed-service-v2/domain/redis/src/main/kotlin/com/hyoseok/wish/service/WishRedisReadService.kt
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
 
 @Service
-@ConditionalOnProperty(prefix = "spring.post.redis", name = ["enable"], havingValue = "true")
+@ConditionalOnProperty(prefix = "spring.wish.redis", name = ["enable"], havingValue = "true")
 class WishRedisReadService(
     private val wishRedisRepository: WishRedisRepository,
 ) {

--- a/sns-feed-service-v2/domain/redis/src/main/kotlin/com/hyoseok/wish/service/WishRedisService.kt
+++ b/sns-feed-service-v2/domain/redis/src/main/kotlin/com/hyoseok/wish/service/WishRedisService.kt
@@ -7,7 +7,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
 
 @Service
-@ConditionalOnProperty(prefix = "spring.post.redis", name = ["enable"], havingValue = "true")
+@ConditionalOnProperty(prefix = "spring.wish.redis", name = ["enable"], havingValue = "true")
 class WishRedisService(
     private val wishRedisTransactionRepository: WishRedisTransactionRepository,
 ) {

--- a/sns-feed-service-v2/domain/redis/src/main/resources/config/custom-domain-redis.yml
+++ b/sns-feed-service-v2/domain/redis/src/main/resources/config/custom-domain-redis.yml
@@ -31,6 +31,17 @@ spring:
           min-idle: 0 # 기본값 0, time-between-eviction-runs있을때만 유효
           max-wait: -1 # 기본값 -1ms, 풀에서 커넥션 얻을때까지 대기 시간, 음수면 무기한
 
+  wish:
+    redis:
+      mode: standalone
+      nodes: localhost:6385
+      lettuce:
+        pool:
+          max-active: 8 # 기본값 8
+          max-idle: 8 # 기본값 8
+          min-idle: 0 # 기본값 0, time-between-eviction-runs있을때만 유효
+          max-wait: -1 # 기본값 -1ms, 풀에서 커넥션 얻을때까지 대기 시간, 음수면 무기한
+
 logging:
   level:
     io.lettuce.core.protocol.CommandHandler: debug
@@ -56,6 +67,17 @@ spring:
     redis:
       mode: standalone
       nodes: localhost:6384
+      lettuce:
+        pool:
+          max-active: 8 # 기본값 8
+          max-idle: 8 # 기본값 8
+          min-idle: 0 # 기본값 0, time-between-eviction-runs있을때만 유효
+          max-wait: -1 # 기본값 -1ms, 풀에서 커넥션 얻을때까지 대기 시간, 음수면 무기한
+
+  wish:
+    redis:
+      mode: standalone
+      nodes: localhost:6385
       lettuce:
         pool:
           max-active: 8 # 기본값 8

--- a/sns-feed-service-v2/domain/redis/src/test/kotlin/com/hyoseok/wish/repository/WishRedisRepositoryTests.kt
+++ b/sns-feed-service-v2/domain/redis/src/test/kotlin/com/hyoseok/wish/repository/WishRedisRepositoryTests.kt
@@ -1,8 +1,8 @@
 package com.hyoseok.wish.repository
 
-import com.hyoseok.config.PostRedisConfig
-import com.hyoseok.config.PostRedisTemplateConfig
 import com.hyoseok.config.RedisEmbbededServerConfig
+import com.hyoseok.config.WishRedisConfig
+import com.hyoseok.config.WishRedisTemplateConfig
 import io.kotest.core.extensions.Extension
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.DescribeSpec
@@ -22,8 +22,8 @@ import org.springframework.test.context.ContextConfiguration
 @ContextConfiguration(
     classes = [
         RedisEmbbededServerConfig::class,
-        PostRedisConfig::class,
-        PostRedisTemplateConfig::class,
+        WishRedisConfig::class,
+        WishRedisTemplateConfig::class,
         WishRedisRepositoryImpl::class,
         WishRedisRepository::class,
     ],
@@ -34,7 +34,7 @@ internal class WishRedisRepositoryTests : DescribeSpec() {
     override fun isolationMode(): IsolationMode = IsolationMode.InstancePerLeaf
 
     @Autowired
-    @Qualifier("postRedisTemplate")
+    @Qualifier("wishRedisTemplate")
     private lateinit var redisTemplate: RedisTemplate<String, String?>
 
     @Autowired

--- a/sns-feed-service-v2/domain/redis/src/test/kotlin/com/hyoseok/wish/repository/WishRedisTransactionRepositoryTests.kt
+++ b/sns-feed-service-v2/domain/redis/src/test/kotlin/com/hyoseok/wish/repository/WishRedisTransactionRepositoryTests.kt
@@ -1,8 +1,8 @@
 package com.hyoseok.wish.repository
 
-import com.hyoseok.config.PostRedisConfig
-import com.hyoseok.config.PostRedisTemplateConfig
 import com.hyoseok.config.RedisEmbbededServerConfig
+import com.hyoseok.config.WishRedisConfig
+import com.hyoseok.config.WishRedisTemplateConfig
 import com.hyoseok.wish.entity.WishCache
 import io.kotest.core.extensions.Extension
 import io.kotest.core.spec.IsolationMode
@@ -24,8 +24,8 @@ import org.springframework.test.context.ContextConfiguration
 @ContextConfiguration(
     classes = [
         RedisEmbbededServerConfig::class,
-        PostRedisConfig::class,
-        PostRedisTemplateConfig::class,
+        WishRedisConfig::class,
+        WishRedisTemplateConfig::class,
         WishRedisRepositoryImpl::class,
         WishRedisTransactionRepositoryImpl::class,
         WishRedisRepository::class,
@@ -38,7 +38,7 @@ internal class WishRedisTransactionRepositoryTests : DescribeSpec() {
     override fun isolationMode(): IsolationMode = IsolationMode.InstancePerLeaf
 
     @Autowired
-    @Qualifier("postRedisTemplate")
+    @Qualifier("wishRedisTemplate")
     private lateinit var redisTemplate: RedisTemplate<String, String?>
 
     @Autowired

--- a/sns-feed-service-v2/domain/redis/src/test/resources/application.yml
+++ b/sns-feed-service-v2/domain/redis/src/test/resources/application.yml
@@ -26,6 +26,18 @@ spring:
           min-idle: 0 # 기본값 0, time-between-eviction-runs있을때만 유효
           max-wait: -1 # 기본값 -1ms, 풀에서 커넥션 얻을때까지 대기 시간, 음수면 무기한
 
+  wish:
+    redis:
+      enable: true
+      mode: standalone
+      nodes: localhost:6379
+      lettuce:
+        pool:
+          max-active: 8 # 기본값 8
+          max-idle: 8 # 기본값 8
+          min-idle: 0 # 기본값 0, time-between-eviction-runs있을때만 유효
+          max-wait: -1 # 기본값 -1ms, 풀에서 커넥션 얻을때까지 대기 시간, 음수면 무기한
+
 logging:
   level:
     io.lettuce.core.protocol.CommandHandler: debug


### PR DESCRIPTION
### [ 내용 ]

- `Post`, `Wish` 를 하나의 Redis 서버에서 공용으로 사용하고 있었는데, 서버를 분리 했음.