### PR TITLE
[PR] 타임라인 새로고침 기능 개발

### DIFF
--- a/sns-feed-service-v2/application/query-api/src/main/kotlin/com/hyoseok/config/resilience4j/ratelimiter/RateLimiterConfig.kt
+++ b/sns-feed-service-v2/application/query-api/src/main/kotlin/com/hyoseok/config/resilience4j/ratelimiter/RateLimiterConfig.kt
@@ -1,8 +1,10 @@
 package com.hyoseok.config.resilience4j.ratelimiter
 
 import com.hyoseok.config.resilience4j.ratelimiter.RateLimiterConfig.Name.FIND_POSTS_USECASE
+import com.hyoseok.config.resilience4j.ratelimiter.RateLimiterConfig.Name.FIND_POST_REFRESH_TIMELINE_USECASE
 import com.hyoseok.config.resilience4j.ratelimiter.RateLimiterConfig.Name.FIND_POST_TIMELINE_USECASE
 import com.hyoseok.config.resilience4j.ratelimiter.RateLimiterConfig.Name.FIND_POST_USECASE
+import com.hyoseok.config.resilience4j.ratelimiter.property.FindPostRefreshTimelineUsecaseProperty
 import com.hyoseok.config.resilience4j.ratelimiter.property.FindPostTimelineUsecaseProperty
 import com.hyoseok.config.resilience4j.ratelimiter.property.FindPostUsecaseProperty
 import com.hyoseok.config.resilience4j.ratelimiter.property.FindPostsUsecaseProperty
@@ -17,34 +19,37 @@ import java.time.Duration
 @Configuration
 @EnableConfigurationProperties(
     value = [
-        FindPostsUsecaseProperty::class,
+        FindPostRefreshTimelineUsecaseProperty::class,
         FindPostTimelineUsecaseProperty::class,
+        FindPostsUsecaseProperty::class,
         FindPostUsecaseProperty::class,
     ],
 )
 class RateLimiterConfig(
-    private val findPostsUsecaseProperty: FindPostsUsecaseProperty,
+    private val findPostRefreshTimelineUsecaseProperty: FindPostRefreshTimelineUsecaseProperty,
     private val findPostTimelineUsecaseProperty: FindPostTimelineUsecaseProperty,
+    private val findPostsUsecaseProperty: FindPostsUsecaseProperty,
     private val findPostUsecaseProperty: FindPostUsecaseProperty,
 ) {
 
     object Name {
-        const val FIND_POSTS_USECASE = "findPostsUsecase"
+        const val FIND_POST_REFRESH_TIMELINE_USECASE = "findPostRefreshTimelineUsecase"
         const val FIND_POST_TIMELINE_USECASE = "findPostTimelineUsecase"
+        const val FIND_POSTS_USECASE = "findPostsUsecase"
         const val FIND_POST_USECASE = "findPostUsecase"
     }
 
     @Bean
-    fun findPostsUsecaseRateLimiter(): RateLimiter {
+    fun findPostRefreshTimelineUsecaseRateLimiter(): RateLimiter {
         val rateLimiterConfig: RateLimiterConfig = RateLimiterConfig.custom()
-            .limitForPeriod(findPostsUsecaseProperty.limitForPeriod)
-            .limitRefreshPeriod(Duration.ofSeconds(findPostsUsecaseProperty.limitRefreshPeriod))
-            .timeoutDuration(Duration.ofSeconds(findPostsUsecaseProperty.timeoutDuration))
+            .limitForPeriod(findPostRefreshTimelineUsecaseProperty.limitForPeriod)
+            .limitRefreshPeriod(Duration.ofSeconds(findPostRefreshTimelineUsecaseProperty.limitRefreshPeriod))
+            .timeoutDuration(Duration.ofSeconds(findPostRefreshTimelineUsecaseProperty.timeoutDuration))
             .build()
 
         return RateLimiterRegistry
             .of(rateLimiterConfig)
-            .rateLimiter(FIND_POSTS_USECASE)
+            .rateLimiter(FIND_POST_REFRESH_TIMELINE_USECASE)
     }
 
     @Bean
@@ -58,6 +63,19 @@ class RateLimiterConfig(
         return RateLimiterRegistry
             .of(rateLimiterConfig)
             .rateLimiter(FIND_POST_TIMELINE_USECASE)
+    }
+
+    @Bean
+    fun findPostsUsecaseRateLimiter(): RateLimiter {
+        val rateLimiterConfig: RateLimiterConfig = RateLimiterConfig.custom()
+            .limitForPeriod(findPostsUsecaseProperty.limitForPeriod)
+            .limitRefreshPeriod(Duration.ofSeconds(findPostsUsecaseProperty.limitRefreshPeriod))
+            .timeoutDuration(Duration.ofSeconds(findPostsUsecaseProperty.timeoutDuration))
+            .build()
+
+        return RateLimiterRegistry
+            .of(rateLimiterConfig)
+            .rateLimiter(FIND_POSTS_USECASE)
     }
 
     @Bean

--- a/sns-feed-service-v2/application/query-api/src/main/kotlin/com/hyoseok/config/resilience4j/ratelimiter/property/FindPostRefreshTimelineUsecaseProperty.kt
+++ b/sns-feed-service-v2/application/query-api/src/main/kotlin/com/hyoseok/config/resilience4j/ratelimiter/property/FindPostRefreshTimelineUsecaseProperty.kt
@@ -1,0 +1,12 @@
+package com.hyoseok.config.resilience4j.ratelimiter.property
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConstructorBinding
+@ConfigurationProperties(value = "resilience4j.ratelimiter.usecase.find-post-refresh-timeline")
+data class FindPostRefreshTimelineUsecaseProperty(
+    val limitForPeriod: Int,
+    val limitRefreshPeriod: Long,
+    val timeoutDuration: Long,
+)

--- a/sns-feed-service-v2/application/query-api/src/main/kotlin/com/hyoseok/controller/PostController.kt
+++ b/sns-feed-service-v2/application/query-api/src/main/kotlin/com/hyoseok/controller/PostController.kt
@@ -2,22 +2,25 @@ package com.hyoseok.controller
 
 import com.hyoseok.post.dto.PostDto
 import com.hyoseok.response.SuccessResponse
-import com.hyoseok.usecase.FindPostsTimelineUsecase
 import com.hyoseok.usecase.FindPostUsecase
+import com.hyoseok.usecase.FindPostsRefreshTimelineUsecase
+import com.hyoseok.usecase.FindPostsTimelineUsecase
 import com.hyoseok.usecase.FindPostsUsecase
 import com.hyoseok.util.PageByPosition
 import com.hyoseok.util.PageRequestByPosition
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/posts")
 class PostController(
-    private val findPostsUsecase: FindPostsUsecase,
+    private val findPostsRefreshTimelineUsecase: FindPostsRefreshTimelineUsecase,
     private val findPostsTimelineUsecase: FindPostsTimelineUsecase,
+    private val findPostsUsecase: FindPostsUsecase,
     private val findPostUsecase: FindPostUsecase,
 ) {
 
@@ -49,9 +52,15 @@ class PostController(
         ResponseEntity.ok(
             SuccessResponse(
                 data = findPostsTimelineUsecase.execute(
-                    memberId,
+                    memberId = memberId,
                     pageRequestByPosition = pageRequestByPosition,
                 ),
             ),
         )
+
+    @PostMapping("/members/{memberId}/refresh/timeline")
+    fun refreshTimeline(@PathVariable memberId: Long): ResponseEntity<SuccessResponse<String>> {
+        findPostsRefreshTimelineUsecase.execute(memberId = memberId)
+        return ResponseEntity.ok(SuccessResponse(data = "refresh completed"))
+    }
 }

--- a/sns-feed-service-v2/application/query-api/src/main/kotlin/com/hyoseok/usecase/FindPostsRefreshTimelineUsecase.kt
+++ b/sns-feed-service-v2/application/query-api/src/main/kotlin/com/hyoseok/usecase/FindPostsRefreshTimelineUsecase.kt
@@ -1,0 +1,51 @@
+package com.hyoseok.usecase
+
+import com.hyoseok.config.resilience4j.ratelimiter.RateLimiterConfig.Name.FIND_POST_REFRESH_TIMELINE_USECASE
+import com.hyoseok.exception.QueryApiRateLimitException
+import com.hyoseok.feed.service.FeedRedisService
+import com.hyoseok.follow.service.FollowReadService
+import com.hyoseok.post.dto.PostDto
+import com.hyoseok.post.service.PostReadService
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class FindPostsRefreshTimelineUsecase(
+    private val feedRedisService: FeedRedisService,
+    private val followReadService: FollowReadService,
+    private val postReadService: PostReadService,
+) {
+
+    private val logger = KotlinLogging.logger {}
+
+    @RateLimiter(name = FIND_POST_REFRESH_TIMELINE_USECASE, fallbackMethod = "fallbackExecute")
+    fun execute(memberId: Long) {
+        val findFolloweeMaxLimit: Long = 1_000
+        val followeeIds: List<Long> = followReadService.findInfluencerFolloweeIds(
+            followerId = memberId,
+            findFolloweeMaxLimit = findFolloweeMaxLimit,
+        )
+        val toCreatedAt: LocalDateTime = LocalDateTime.now().withNano(0)
+        val fromCreatedAt: LocalDateTime = toCreatedAt.minusMinutes(10)
+        val postLimit: Long = 1_000
+        val postOffset: Long = 0
+        val postDtos: List<PostDto> = postReadService.findPosts(
+            memberIds = followeeIds,
+            fromCreatedAt = fromCreatedAt,
+            toCreatedAt = toCreatedAt,
+            limit = postLimit,
+            offset = postOffset,
+        )
+
+        postDtos.forEach {
+            feedRedisService.create(memberId = memberId, postId = it.id)
+        }
+    }
+
+    private fun fallbackExecute(exception: Exception) {
+        logger.error { exception.localizedMessage }
+        throw QueryApiRateLimitException(message = "일시적으로 타임라인을 새로고침 할 수 없습니다. 잠시 후에 다시 시도해주세요.")
+    }
+}

--- a/sns-feed-service-v2/application/query-api/src/main/kotlin/com/hyoseok/usecase/FindPostsTimelineUsecase.kt
+++ b/sns-feed-service-v2/application/query-api/src/main/kotlin/com/hyoseok/usecase/FindPostsTimelineUsecase.kt
@@ -4,7 +4,6 @@ import com.hyoseok.config.resilience4j.ratelimiter.RateLimiterConfig.Name.FIND_P
 import com.hyoseok.exception.QueryApiRateLimitException
 import com.hyoseok.feed.dto.FeedCacheDto
 import com.hyoseok.feed.service.FeedRedisReadService
-import com.hyoseok.follow.service.FollowReadService
 import com.hyoseok.mapper.PostCacheDtoMapper
 import com.hyoseok.mapper.PostDtoMapper
 import com.hyoseok.post.dto.PostCacheDto
@@ -24,7 +23,6 @@ import org.springframework.stereotype.Service
 @Service
 class FindPostsTimelineUsecase(
     private val feedRedisReadService: FeedRedisReadService,
-    private val followReadService: FollowReadService,
     private val postRedisReadService: PostRedisReadService,
     private val postRedisService: PostRedisService,
     private val postReadService: PostReadService,

--- a/sns-feed-service-v2/application/query-api/src/main/resources/application.yml
+++ b/sns-feed-service-v2/application/query-api/src/main/resources/application.yml
@@ -20,14 +20,18 @@ spring:
 resilience4j:
   ratelimiter:
     usecase:
+      find-post-refresh-timeline:
+        limitForPeriod: 3000 # limitRefreshPeriod 기간 동안 허용되는 요청 수
+        limitRefreshPeriod: 1 # limitRefresh 기간 (초)
+        timeoutDuration: 3 # 권한 acquire(허가)를 위해 스레드가 대기하는 시간 (초)
+      find-post-timeline:
+        limitForPeriod: 3000
+        limitRefreshPeriod: 1
+        timeoutDuration: 3
       find-posts:
         limitForPeriod: 3000
         limitRefreshPeriod: 1
         timeoutDuration: 3
-      find-post-timeline:
-        limitForPeriod: 3000 # limitRefreshPeriod 기간 동안 허용되는 요청 수
-        limitRefreshPeriod: 1 # limitRefresh 기간 (초)
-        timeoutDuration: 3 # 권한 acquire(허가)를 위해 스레드가 대기하는 시간 (초)
       #      registerHealthIndicator: true # actuator를 통해 ratelimiter 상태를 체크하기 위한 여부
       find-post:
         limitForPeriod: 3000

--- a/sns-feed-service-v2/domain/rds/src/main/kotlin/com/hyoseok/post/service/PostReadService.kt
+++ b/sns-feed-service-v2/domain/rds/src/main/kotlin/com/hyoseok/post/service/PostReadService.kt
@@ -64,4 +64,24 @@ class PostReadService(
             offset = start,
         ).map { PostDto(post = it) }
     }
+
+    fun findPosts(
+        memberIds: List<Long>,
+        fromCreatedAt: LocalDateTime,
+        toCreatedAt: LocalDateTime,
+        limit: Long,
+        offset: Long,
+    ): List<PostDto> {
+        if (memberIds.isEmpty()) {
+            return listOf()
+        }
+
+        return postReadRepository.findAllByMemberIdsAndCreatedAtAndLimitAndOffset(
+            memberIds = memberIds,
+            fromCreatedAt = fromCreatedAt,
+            toCreatedAt = toCreatedAt,
+            limit = limit,
+            offset = offset,
+        ).map { PostDto(post = it) }
+    }
 }


### PR DESCRIPTION
### [ 이슈 ]

- #189

### [ 내용 ]

- `FindPostsRefreshTimelineUsecase` 생성
  -  `1,000,000명` 팔로워를 가진 인플루언서를 1,000개 조회한다.
  -  `1,000` 명의 인플루언서 `followeeId` 리스트를 통해 최근 `10분` 동안 등록한 `Post` 를 `1,000` 개 조회한다.
  -  Loop를 통해 `0 ~ 1,000` 개의 `Feed` 캐시를 적재한다.