### PR TITLE
[PR] 팬아웃 Push 로직 개선

### DIFF
--- a/sns-feed-service-v2/domain/rds/src/main/kotlin/com/hyoseok/follow/dto/FollowDto.kt
+++ b/sns-feed-service-v2/domain/rds/src/main/kotlin/com/hyoseok/follow/dto/FollowDto.kt
@@ -1,5 +1,6 @@
 package com.hyoseok.follow.dto
 
+import com.hyoseok.follow.entity.Follow
 import java.time.LocalDateTime
 
 data class FollowDto(
@@ -7,7 +8,15 @@ data class FollowDto(
     val followerId: Long,
     val followeeId: Long,
     val createdAt: LocalDateTime,
-)
+) {
+
+    companion object {
+        operator fun invoke(follow: Follow): FollowDto =
+            with(receiver = follow) {
+                FollowDto(id = id!!, followerId = followerId, followeeId = followeeId, createdAt = createdAt)
+            }
+    }
+}
 
 data class FollowCreateDto(
     val followerId: Long,

--- a/sns-feed-service-v2/domain/rds/src/main/kotlin/com/hyoseok/follow/repository/FollowCountReadRepositoryImpl.kt
+++ b/sns-feed-service-v2/domain/rds/src/main/kotlin/com/hyoseok/follow/repository/FollowCountReadRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.hyoseok.follow.repository
 
 import com.hyoseok.follow.entity.FollowCount
 import com.hyoseok.follow.entity.QFollowCount.followCount
+import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
@@ -15,6 +16,8 @@ class FollowCountReadRepositoryImpl(
     override fun findByMemberId(memberId: Long): FollowCount? =
         jpaQueryFactory
             .selectFrom(followCount)
-            .where(followCount.memberId.eq(memberId))
+            .where(followCountMemberIdEq(memberId = memberId))
             .fetchOne()
+
+    private fun followCountMemberIdEq(memberId: Long): BooleanExpression = followCount.memberId.eq(memberId)
 }

--- a/sns-feed-service-v2/domain/rds/src/main/kotlin/com/hyoseok/follow/repository/FollowReadRepository.kt
+++ b/sns-feed-service-v2/domain/rds/src/main/kotlin/com/hyoseok/follow/repository/FollowReadRepository.kt
@@ -7,6 +7,7 @@ interface FollowReadRepository {
     fun countByFollowerId(followerId: Long): Long
     fun findById(id: Long): Follow
     fun findAllByFolloweeIdAndLimitAndOffset(followeeId: Long, limit: Long, offset: Long): Pair<Long, List<Follow>>
+    fun findAllByFolloweeIdAndLastIdAndLimit(followeeId: Long, lastId: Long = 0, limit: Long): List<Follow>
     fun findAllByFollowerIdAndLimitAndOffset(followerId: Long, limit: Long, offset: Long): Pair<Long, List<Follow>>
     fun findAllByFollowerIdAndLimitOrderByIdDesc(followerId: Long, checkTotalFollower: Long, limit: Long): List<Follow>
 }

--- a/sns-feed-service-v2/domain/rds/src/main/kotlin/com/hyoseok/follow/repository/FollowReadRepositoryImpl.kt
+++ b/sns-feed-service-v2/domain/rds/src/main/kotlin/com/hyoseok/follow/repository/FollowReadRepositoryImpl.kt
@@ -56,6 +56,16 @@ class FollowReadRepositoryImpl(
                 .fetch(),
         )
 
+    override fun findAllByFolloweeIdAndLastIdAndLimit(followeeId: Long, lastId: Long, limit: Long): List<Follow> =
+        jpaQueryFactory
+            .selectFrom(follow)
+            .where(
+                followFolloweeIdEq(followeeId = followeeId),
+                followIdGt(id = lastId),
+            )
+            .limit(limit)
+            .fetch()
+
     override fun findAllByFollowerIdAndLimitAndOffset(
         followerId: Long,
         limit: Long,
@@ -89,6 +99,13 @@ class FollowReadRepositoryImpl(
             .fetch()
 
     private fun followIdEq(id: Long): BooleanExpression = follow.id.eq(id)
+
+    private fun followIdGt(id: Long): BooleanExpression? {
+        if (id == 0L) {
+            return null
+        }
+        return follow.id.gt(id)
+    }
 
     private fun followFolloweeIdEq(followeeId: Long): BooleanExpression = follow.followeeId.eq(followeeId)
 

--- a/sns-feed-service-v2/domain/rds/src/test/kotlin/com/hyoseok/follow/repository/FollowRepositoryTests.kt
+++ b/sns-feed-service-v2/domain/rds/src/test/kotlin/com/hyoseok/follow/repository/FollowRepositoryTests.kt
@@ -202,5 +202,45 @@ internal class FollowRepositoryTests : DescribeSpec() {
                 totalCount.shouldBe(follows.size)
             }
         }
+
+        this.describe("findAllByFolloweeIdAndLastIdAndLimit 메서드는") {
+            it("lastId를 기준으로 limit 만큼 팔로워를 가져온다") {
+                // given
+                val followeeId = 1L
+                val follows: List<Follow> = (2L..11L).map { Follow(followerId = it, followeeId = followeeId) }
+                val followCount =
+                    FollowCount(memberId = followeeId, totalFollowee = 0, totalFollower = follows.size.toLong())
+
+                withContext(Dispatchers.IO) {
+                    followRepository.saveAll(follows)
+                    followCountRepository.save(followCount)
+                }
+
+                val lastId = 0L
+                val limit = 4L
+
+                // when
+                val findFollows1: List<Follow> = followReadRepository.findAllByFolloweeIdAndLastIdAndLimit(
+                    followeeId = followeeId,
+                    lastId = lastId,
+                    limit = limit,
+                )
+                val findFollows2: List<Follow> = followReadRepository.findAllByFolloweeIdAndLastIdAndLimit(
+                    followeeId = followeeId,
+                    lastId = findFollows1.last().id!!,
+                    limit = limit,
+                )
+                val findFollows3: List<Follow> = followReadRepository.findAllByFolloweeIdAndLastIdAndLimit(
+                    followeeId = followeeId,
+                    lastId = findFollows2.last().id!!,
+                    limit = limit,
+                )
+
+                // then
+                findFollows1.shouldHaveSize(limit.toInt())
+                findFollows2.shouldHaveSize(limit.toInt())
+                findFollows3.shouldHaveSize(limit.minus(2).toInt())
+            }
+        }
     }
 }


### PR DESCRIPTION
### [ 이슈 ]

- #189

### [ 내용 ]

- 팬아웃 Push 처리시, `limit`, `offset` 을 기반으로 `followerId` 리스트를 조회 했었는데, `nooffset (offset 사용하지 않음)` 방식으로 조회 쿼리 개선