### PR TITLE
[PR] 타임라인 새로고침 기능 수정

### DIFF
--- a/sns-feed-service-v2/application/api/src/test/kotlin/com/hyoseok/usecase/CreateFollowMemberUsecaseTests.kt
+++ b/sns-feed-service-v2/application/api/src/test/kotlin/com/hyoseok/usecase/CreateFollowMemberUsecaseTests.kt
@@ -26,12 +26,14 @@ internal class CreateFollowMemberUsecaseTests : BehaviorSpec(
                 name = "팔로워",
                 influencer = false,
                 createdAt = LocalDateTime.now().withNano(0),
+                lastLoginDatetime = LocalDateTime.now().withNano(0),
             )
             val followeeMemberDto = MemberDto(
                 id = 2L,
                 name = "팔로이",
                 influencer = false,
                 createdAt = LocalDateTime.now().withNano(0),
+                lastLoginDatetime = LocalDateTime.now().withNano(0),
             )
             val followCreateDto = FollowCreateDto(
                 followerId = followerMemberDto.id,

--- a/sns-feed-service-v2/application/api/src/test/kotlin/com/hyoseok/usecase/CreatePostUsecaseTests.kt
+++ b/sns-feed-service-v2/application/api/src/test/kotlin/com/hyoseok/usecase/CreatePostUsecaseTests.kt
@@ -25,7 +25,7 @@ import java.time.LocalDateTime
 internal class CreatePostUsecaseTests : BehaviorSpec(
     {
         val mockFeedKafkaProducer: FeedKafkaProducer = mockk(relaxed = true)
-        val mockFollowReadService: FollowReadService = mockk()
+        val mockFollowReadService: FollowReadService = mockk(relaxed = true)
         val mockMemberReadService: MemberReadService = mockk()
         val mockPostService: PostService = mockk()
         val mockPostRedisService: PostRedisService = mockk()

--- a/sns-feed-service-v2/application/api/src/test/kotlin/com/hyoseok/usecase/CreatePostUsecaseTests.kt
+++ b/sns-feed-service-v2/application/api/src/test/kotlin/com/hyoseok/usecase/CreatePostUsecaseTests.kt
@@ -51,6 +51,7 @@ internal class CreatePostUsecaseTests : BehaviorSpec(
                 name = "사용자",
                 influencer = false,
                 createdAt = LocalDateTime.now().withNano(0),
+                lastLoginDatetime = LocalDateTime.now().withNano(0),
             )
             val postCreateDto = PostCreateDto(
                 memberId = memberDto.id,

--- a/sns-feed-service-v2/application/api/src/test/kotlin/com/hyoseok/usecase/CreateWishUsecaseTests.kt
+++ b/sns-feed-service-v2/application/api/src/test/kotlin/com/hyoseok/usecase/CreateWishUsecaseTests.kt
@@ -26,8 +26,13 @@ internal class CreateWishUsecaseTests : BehaviorSpec(
         )
 
         given("좋아요를 처리하기 위해 아래와 같은 상황이 주어지면") {
-            val memberDto =
-                MemberDto(id = 1L, name = "name", influencer = false, createdAt = LocalDateTime.now().withNano(0))
+            val memberDto = MemberDto(
+                id = 1L,
+                name = "name",
+                influencer = false,
+                createdAt = LocalDateTime.now().withNano(0),
+                lastLoginDatetime = LocalDateTime.now().withNano(0),
+            )
             val postDto = PostDto(
                 id = 1L,
                 memberId = 2L,

--- a/sns-feed-service-v2/application/query-api/src/main/kotlin/com/hyoseok/usecase/FindPostsRefreshTimelineUsecase.kt
+++ b/sns-feed-service-v2/application/query-api/src/main/kotlin/com/hyoseok/usecase/FindPostsRefreshTimelineUsecase.kt
@@ -39,7 +39,7 @@ class FindPostsRefreshTimelineUsecase(
             memberIds = followeeIds,
             fromCreatedAt = memberDto.lastLoginDatetime, // 마지막 접속 날짜
             toCreatedAt = LocalDateTime.now().withNano(0),
-            limit = 1_000,
+            limit = 500,
             offset = 0,
         )
 

--- a/sns-feed-service-v2/application/query-api/src/main/kotlin/com/hyoseok/usecase/FindPostsRefreshTimelineUsecase.kt
+++ b/sns-feed-service-v2/application/query-api/src/main/kotlin/com/hyoseok/usecase/FindPostsRefreshTimelineUsecase.kt
@@ -39,7 +39,7 @@ class FindPostsRefreshTimelineUsecase(
             memberIds = followeeIds,
             fromCreatedAt = memberDto.lastLoginDatetime, // 마지막 접속 날짜
             toCreatedAt = LocalDateTime.now().withNano(0),
-            limit = 500,
+            limit = 100,
             offset = 0,
         )
 

--- a/sns-feed-service-v2/application/query-api/src/main/kotlin/com/hyoseok/usecase/FindPostsRefreshTimelineUsecase.kt
+++ b/sns-feed-service-v2/application/query-api/src/main/kotlin/com/hyoseok/usecase/FindPostsRefreshTimelineUsecase.kt
@@ -4,9 +4,15 @@ import com.hyoseok.config.resilience4j.ratelimiter.RateLimiterConfig.Name.FIND_P
 import com.hyoseok.exception.QueryApiRateLimitException
 import com.hyoseok.feed.service.FeedRedisService
 import com.hyoseok.follow.service.FollowReadService
+import com.hyoseok.member.dto.MemberDto
+import com.hyoseok.member.service.MemberReadService
+import com.hyoseok.member.service.MemberService
 import com.hyoseok.post.dto.PostDto
 import com.hyoseok.post.service.PostReadService
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
@@ -15,6 +21,8 @@ import java.time.LocalDateTime
 class FindPostsRefreshTimelineUsecase(
     private val feedRedisService: FeedRedisService,
     private val followReadService: FollowReadService,
+    private val memberService: MemberService,
+    private val memberReadService: MemberReadService,
     private val postReadService: PostReadService,
 ) {
 
@@ -22,25 +30,25 @@ class FindPostsRefreshTimelineUsecase(
 
     @RateLimiter(name = FIND_POST_REFRESH_TIMELINE_USECASE, fallbackMethod = "fallbackExecute")
     fun execute(memberId: Long) {
-        val findFolloweeMaxLimit: Long = 1_000
         val followeeIds: List<Long> = followReadService.findInfluencerFolloweeIds(
             followerId = memberId,
-            findFolloweeMaxLimit = findFolloweeMaxLimit,
+            findFolloweeMaxLimit = 1_000,
         )
-        val toCreatedAt: LocalDateTime = LocalDateTime.now().withNano(0)
-        val fromCreatedAt: LocalDateTime = toCreatedAt.minusMinutes(10)
-        val postLimit: Long = 1_000
-        val postOffset: Long = 0
+        val memberDto: MemberDto = memberReadService.findMember(id = memberId)
         val postDtos: List<PostDto> = postReadService.findPosts(
             memberIds = followeeIds,
-            fromCreatedAt = fromCreatedAt,
-            toCreatedAt = toCreatedAt,
-            limit = postLimit,
-            offset = postOffset,
+            fromCreatedAt = memberDto.lastLoginDatetime, // 마지막 접속 날짜
+            toCreatedAt = LocalDateTime.now().withNano(0),
+            limit = 1_000,
+            offset = 0,
         )
 
         postDtos.forEach {
             feedRedisService.create(memberId = memberId, postId = it.id)
+        }
+
+        CoroutineScope(context = Dispatchers.IO).launch {
+            memberService.updateLastLoginDatetime(memberId = memberId)
         }
     }
 

--- a/sns-feed-service-v2/application/query-api/src/main/kotlin/com/hyoseok/usecase/FindPostsRefreshTimelineUsecase.kt
+++ b/sns-feed-service-v2/application/query-api/src/main/kotlin/com/hyoseok/usecase/FindPostsRefreshTimelineUsecase.kt
@@ -32,14 +32,14 @@ class FindPostsRefreshTimelineUsecase(
     fun execute(memberId: Long) {
         val followeeIds: List<Long> = followReadService.findInfluencerFolloweeIds(
             followerId = memberId,
-            findFolloweeMaxLimit = 1_000,
+            findFolloweeMaxLimit = 1_000, // 비즈니스 요구사항에 맞게 조정하면 되지만, 1 ~ 1,000 범위에서만 가져오자
         )
         val memberDto: MemberDto = memberReadService.findMember(id = memberId)
         val postDtos: List<PostDto> = postReadService.findPosts(
             memberIds = followeeIds,
             fromCreatedAt = memberDto.lastLoginDatetime, // 마지막 접속 날짜
             toCreatedAt = LocalDateTime.now().withNano(0),
-            limit = 100,
+            limit = 100, // 비즈니스 요구사항에 맞게 조정하면 되지만, 가능하다면 1 ~ 1,000 범위에서만 가져오자
             offset = 0,
         )
 

--- a/sns-feed-service-v2/domain/rds/src/main/kotlin/com/hyoseok/member/dto/MemberDto.kt
+++ b/sns-feed-service-v2/domain/rds/src/main/kotlin/com/hyoseok/member/dto/MemberDto.kt
@@ -7,6 +7,7 @@ data class MemberDto(
     val name: String,
     val influencer: Boolean,
     val createdAt: LocalDateTime,
+    val lastLoginDatetime: LocalDateTime,
 )
 
 data class MemberCreateDto(

--- a/sns-feed-service-v2/domain/rds/src/main/kotlin/com/hyoseok/member/entity/Member.kt
+++ b/sns-feed-service-v2/domain/rds/src/main/kotlin/com/hyoseok/member/entity/Member.kt
@@ -16,6 +16,7 @@ class Member private constructor(
     influencer: Int,
     createdAt: LocalDateTime,
     updatedAt: LocalDateTime,
+    lastLoginDatetime: LocalDateTime,
 ) : BaseEntity(createdAt = createdAt) {
 
     @Column(name = "name", nullable = false)
@@ -30,8 +31,12 @@ class Member private constructor(
     var updatedAt: LocalDateTime = updatedAt
         protected set
 
+    @Column(name = "last_login_datetime", nullable = false, columnDefinition = "DATETIME")
+    var lastLoginDatetime: LocalDateTime = lastLoginDatetime
+        protected set
+
     override fun toString(): String = "Member(id=$id, name=$name, influencer=$influencer, " +
-        "createdAt=$createdAt, updatedAt=$updatedAt)"
+        "createdAt=$createdAt, updatedAt=$updatedAt, lastLoginDatetime=$lastLoginDatetime)"
 
     object ErrorMessage {
         const val MAX_LIMIT = "입력할 수 있는 이름의 길이를 초과했습니다"
@@ -45,7 +50,13 @@ class Member private constructor(
         operator fun invoke(name: String): Member {
             validateName(name = name)
             val nowDatetime: LocalDateTime = LocalDateTime.now()
-            return Member(name = name, influencer = INFLUENCER_FALSE, createdAt = nowDatetime, updatedAt = nowDatetime)
+            return Member(
+                name = name,
+                influencer = INFLUENCER_FALSE,
+                createdAt = nowDatetime,
+                updatedAt = nowDatetime,
+                lastLoginDatetime = nowDatetime,
+            )
         }
 
         private fun validateName(name: String) {
@@ -59,5 +70,9 @@ class Member private constructor(
 
     fun changeInfluencer(influencer: Boolean) {
         this.influencer = if (influencer) INFLUENCER_TRUE else INFLUENCER_FALSE
+    }
+
+    fun changeLastLoginDatetime(lastLoginDatetime: LocalDateTime) {
+        this.lastLoginDatetime = lastLoginDatetime
     }
 }

--- a/sns-feed-service-v2/domain/rds/src/main/kotlin/com/hyoseok/member/service/MemberReadService.kt
+++ b/sns-feed-service-v2/domain/rds/src/main/kotlin/com/hyoseok/member/service/MemberReadService.kt
@@ -12,6 +12,12 @@ class MemberReadService(
 ) {
     fun findMember(id: Long): MemberDto =
         with(receiver = memberReadRepository.findById(id = id)) {
-            MemberDto(id = id, name = name, influencer = getInfluencer(), createdAt = createdAt)
+            MemberDto(
+                id = id,
+                name = name,
+                influencer = getInfluencer(),
+                createdAt = createdAt,
+                lastLoginDatetime = lastLoginDatetime,
+            )
         }
 }

--- a/sns-feed-service-v2/domain/rds/src/main/kotlin/com/hyoseok/member/service/MemberService.kt
+++ b/sns-feed-service-v2/domain/rds/src/main/kotlin/com/hyoseok/member/service/MemberService.kt
@@ -8,6 +8,7 @@ import com.hyoseok.member.repository.MemberRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 /*
 * 도메인 비즈니스
@@ -24,12 +25,24 @@ class MemberService(
             .run { memberRepository.save(this) }
             .let {
                 with(receiver = it) {
-                    MemberDto(id = id!!, name = name, influencer = getInfluencer(), createdAt = createdAt)
+                    MemberDto(
+                        id = id!!,
+                        name = name,
+                        influencer = getInfluencer(),
+                        createdAt = createdAt,
+                        lastLoginDatetime = lastLoginDatetime,
+                    )
                 }
             }
 
     fun updateInfluener(memberId: Long) {
         memberRepository.findByIdOrNull(id = memberId)
             ?.changeInfluencer(influencer = true) ?: throw NoSuchElementException(NOT_FOUND_MEMBER)
+    }
+
+    fun updateLastLoginDatetime(memberId: Long) {
+        memberRepository.findByIdOrNull(id = memberId)
+            ?.changeLastLoginDatetime(lastLoginDatetime = LocalDateTime.now().withNano(0))
+            ?: throw NoSuchElementException(NOT_FOUND_MEMBER)
     }
 }


### PR DESCRIPTION
### [ 이슈 ]

- #189

### [ 내용 ]

- `Member` 도메인에 `lastLoginDatetime` 프로퍼티 및 컬럼 추가
- `현재 접속 날짜` 와 `마지막 접속 날짜` 를 기준으로 타임라인 새로고침이 처리 되도록 기능 수정