### PR TITLE
[PR] Feed, Post, Wish 도메인의 경우, Redis 트랜잭션을 사용하지 않기 때문에 Pool 설정 제거

### DIFF
--- a/sns-feed-service-v2/domain/redis/src/main/kotlin/com/hyoseok/config/WishRedisConfig.kt
+++ b/sns-feed-service-v2/domain/redis/src/main/kotlin/com/hyoseok/config/WishRedisConfig.kt
@@ -15,6 +15,7 @@ import org.springframework.data.redis.connection.RedisClusterConfiguration
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration
 import org.springframework.data.redis.connection.RedisStaticMasterReplicaConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.connection.lettuce.LettucePoolingClientConfiguration
 import java.time.Duration
@@ -51,7 +52,7 @@ class WishRedisConfig(
                 logger.info { "wish redis standalone mode" }
 
                 val (host: String, port: Int) = getHostAndPort()
-                LettuceConnectionFactory(RedisStandaloneConfiguration(host, port), lettucePoolingClientConfiguration())
+                LettuceConnectionFactory(RedisStandaloneConfiguration(host, port), lettuceClientConfig())
             }
 
             Replication -> {
@@ -60,13 +61,13 @@ class WishRedisConfig(
                 val (host: String, port: Int) = getHostAndPort()
                 val staticMasterReplicaConfiguration = RedisStaticMasterReplicaConfiguration(host, port)
                 setReplicaNodes(staticMasterReplicaConfiguration = staticMasterReplicaConfiguration)
-                LettuceConnectionFactory(staticMasterReplicaConfiguration, lettucePoolingClientConfiguration())
+                LettuceConnectionFactory(staticMasterReplicaConfiguration, lettuceClientConfig())
             }
 
             Cluster -> {
                 logger.info { "wish redis cluster mode" }
 
-                LettuceConnectionFactory(RedisClusterConfiguration(nodes), lettucePoolingClientConfiguration())
+                LettuceConnectionFactory(RedisClusterConfiguration(nodes), lettuceClientConfig())
             }
         }
 
@@ -97,11 +98,17 @@ class WishRedisConfig(
         poolConfig.setMaxWait(Duration.ofMillis(maxWait))
 
         return LettucePoolingClientConfiguration.builder()
-            .clientName("wish-redis-client")
+            .clientName("wish-redis-pooling-client")
             .readFrom(ReadFrom.REPLICA_PREFERRED)
             .poolConfig(poolConfig)
             .build()
     }
+
+    private fun lettuceClientConfig(): LettuceClientConfiguration =
+        LettuceClientConfiguration.builder()
+            .clientName("wish-redis-client")
+            .readFrom(ReadFrom.REPLICA_PREFERRED)
+            .build()
 
     private fun getHostAndPort(): Pair<String, Int> {
         val splits: List<String> = nodes.first().split(":")

--- a/sns-feed-service-v2/domain/redis/src/main/kotlin/com/hyoseok/feed/service/FeedRedisService.kt
+++ b/sns-feed-service-v2/domain/redis/src/main/kotlin/com/hyoseok/feed/service/FeedRedisService.kt
@@ -1,16 +1,24 @@
 package com.hyoseok.feed.service
 
-import com.hyoseok.feed.repository.FeedRedisTransactionRepository
+import com.hyoseok.feed.entity.FeedCache.Companion.ZSET_FEED_MAX_LIMIT
+import com.hyoseok.feed.entity.FeedCache.Companion.getMemberIdFeedsKey
+import com.hyoseok.feed.repository.FeedRedisRepository
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
+import java.sql.Timestamp
+import java.time.LocalDateTime
 
 @Service
 @ConditionalOnProperty(prefix = "spring.feed.redis", name = ["enable"], havingValue = "true")
 class FeedRedisService(
-    private val feedRedisTransactionRepository: FeedRedisTransactionRepository,
+    private val feedRedisRepository: FeedRedisRepository,
 ) {
 
     fun create(memberId: Long, postId: Long) {
-        feedRedisTransactionRepository.createFeed(memberId = memberId, postId = postId)
+        val score: Double = Timestamp.valueOf(LocalDateTime.now()).time.toDouble()
+        val key: String = getMemberIdFeedsKey(id = memberId)
+
+        feedRedisRepository.zadd(key = key, value = postId, score = score)
+        feedRedisRepository.zremRangeByRank(key = key, start = ZSET_FEED_MAX_LIMIT, end = ZSET_FEED_MAX_LIMIT)
     }
 }


### PR DESCRIPTION
### [ 내용 ]

- `LettucePoolingClientConfiguration` 대신 `LettuceClientConfiguration` 사용 하도록 설정 수정